### PR TITLE
Improved tokenizing

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -12,6 +12,7 @@ use crate::{Parse, Token, TokenKind};
 
 pub struct Tokens<'a> {
     input: &'a str,
+    cursor: Cursor,
     text_mode: TextMode,
 }
 
@@ -19,13 +20,14 @@ impl<'a> Tokens<'a> {
     pub fn parse(input: &'a str) -> Self {
         Self {
             input,
+            cursor: Cursor::default(),
             text_mode: TextMode::Key,
         }
     }
 }
 
 impl<'a> Iterator for Tokens<'a> {
-    type Item = Token;
+    type Item = (Cursor, Token);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.input.is_empty() {
@@ -40,9 +42,21 @@ impl<'a> Iterator for Tokens<'a> {
             _ => TextMode::Key,
         };
 
+        let prev_cursor = self.cursor;
+
+        // Update the cursor to the next token.
+        self.cursor.byte_offset += token.len;
+        self.cursor.line += self.input[..token.len].matches('\n').count();
+        match self.input[..token.len].rfind('\n') {
+            Some(x) => self.cursor.column = token.len - x,
+            None => self.cursor.column += token.len,
+        }
+
+        // Update the input to point to the next token.
         self.input = &self.input[token.len..];
 
-        Some(token)
+        // Ensure we give the cursor for _this_ token and not the next.
+        Some((prev_cursor, token))
     }
 }
 
@@ -71,6 +85,33 @@ fn next_token(input: &str, text_mode: TextMode) -> Option<Token> {
     parser_chain.find_map(|p| p(input))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Cursor {
+    line: usize,
+    column: usize,
+    byte_offset: usize,
+}
+
+impl Default for Cursor {
+    fn default() -> Self {
+        Cursor {
+            line: 1,
+            column: 1,
+            byte_offset: 0,
+        }
+    }
+}
+
+impl Cursor {
+    pub fn new(line: usize, column: usize, byte_offset: usize) -> Self {
+        Cursor {
+            line,
+            column,
+            byte_offset,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -90,7 +131,7 @@ mod test {
                 text
             '''
         "#};
-        let expected = [
+        let expected_tokens = [
             Token::new(TokenKind::TextUnquoted, 3),
             Token::new(TokenKind::Colon, 1),
             Token::new(TokenKind::Whitespace, 1),
@@ -116,9 +157,36 @@ mod test {
             Token::new(TokenKind::TextMulti, 34),
             Token::new(TokenKind::NewLine, 1),
         ];
+        let expected_cursors = [
+            Cursor::new(1, 1, 0),
+            Cursor::new(1, 4, 3),
+            Cursor::new(1, 5, 4),
+            Cursor::new(1, 6, 5),
+            Cursor::new(1, 9, 8),
+            Cursor::new(2, 1, 9),
+            Cursor::new(2, 6, 14),
+            Cursor::new(2, 7, 15),
+            Cursor::new(2, 8, 16),
+            Cursor::new(2, 27, 35),
+            Cursor::new(3, 1, 36),
+            Cursor::new(3, 11, 46),
+            Cursor::new(4, 1, 47),
+            Cursor::new(4, 4, 50),
+            Cursor::new(4, 5, 51),
+            Cursor::new(4, 6, 52),
+            Cursor::new(4, 13, 59),
+            Cursor::new(4, 14, 60),
+            Cursor::new(4, 24, 70),
+            Cursor::new(5, 1, 71),
+            Cursor::new(5, 10, 80),
+            Cursor::new(5, 11, 81),
+            Cursor::new(5, 12, 82),
+            Cursor::new(9, 4, 116),
+        ];
 
         let tokens: Vec<_> = Tokens::parse(input).collect();
-        for (expected, got) in iter::zip(expected, tokens) {
+        let token_spans = iter::zip(expected_cursors, expected_tokens);
+        for (expected, got) in iter::zip(token_spans, tokens) {
             assert_eq!(expected, got);
         }
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -38,7 +38,11 @@ impl<'a> Iterator for Tokens<'a> {
 
         self.text_mode = match token.kind {
             TokenKind::Colon => TextMode::Value,
-            TokenKind::Whitespace => self.text_mode,
+            TokenKind::Whitespace
+            | TokenKind::NewLine
+            | TokenKind::LineComment
+            | TokenKind::HashComment
+            | TokenKind::BlockComment => self.text_mode,
             _ => TextMode::Key,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ mod symbol;
 mod text;
 mod whitespace;
 
+use std::fmt::{self, Display};
+
 pub use boolean::Boolean;
 pub use comment::Comment;
 pub use iter::Tokens;
@@ -58,4 +60,31 @@ pub enum TokenKind {
     TextUnquoted,
     NewLine,
     Whitespace,
+}
+
+impl Display for TokenKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::Boolean => "Boolean",
+            Self::LineComment => "line comment",
+            Self::BlockComment => "block comment",
+            Self::HashComment => "hash comment",
+            Self::Null => "null",
+            Self::Integer => "integer",
+            Self::Float => "float",
+            Self::OpenBrace => "{",
+            Self::CloseBrace => "}",
+            Self::OpenBracket => "[",
+            Self::CloseBracket => "]",
+            Self::Colon => ":",
+            Self::Comma => ",",
+            Self::TextSingle => "single-quoted string",
+            Self::TextDouble => "double-quoted string",
+            Self::TextMulti => "multi-line string",
+            Self::TextUnquoted => "unquoted string",
+            Self::NewLine => "newline",
+            Self::Whitespace => "whitespace",
+        };
+        f.write_str(name)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::fmt::{self, Display};
 
 pub use boolean::Boolean;
 pub use comment::Comment;
-pub use iter::Tokens;
+pub use iter::{Cursor, Tokens};
 pub use key::Key;
 pub use null::Null;
 pub use number::Number;

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -9,7 +9,7 @@ impl Parse for Symbol {
             '{' => TokenKind::OpenBrace,
             '}' => TokenKind::CloseBrace,
             '[' => TokenKind::OpenBracket,
-            ']' => TokenKind::OpenBracket,
+            ']' => TokenKind::CloseBracket,
             ':' => TokenKind::Colon,
             ',' => TokenKind::Comma,
             _ => return None,
@@ -29,7 +29,7 @@ mod test {
             ("{", TokenKind::OpenBrace),
             ("}", TokenKind::CloseBrace),
             ("[", TokenKind::OpenBracket),
-            ("]", TokenKind::OpenBracket),
+            ("]", TokenKind::CloseBracket),
             (":", TokenKind::Colon),
             (",", TokenKind::Comma),
         ];


### PR DESCRIPTION
This PR includes fixes for the tokenizer implementation:

1. Close-brackets are no longer tokenized as open-brackets.
2. Unquoted strings that start off as numbers are no longer parsed as numbers.
3. Whitespace and comments no longer toggle the token iterator back to `Key` mode.
4. String keys are now parsed before numbers, Booleans, and `null`.

Plus some improvements that will make error messages nicer:

1. The token iterator now keeps track of its position in the input and provides "cursors".
2. `TokenKind` now implements `Display`.

Still no inline documentation, but I will get to it.