### PR TITLE
Add README and GitHub Actions workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,35 @@
+name: Rust
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test
+      run: cargo test --verbose
+
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Format
+      run: cargo fmt --check
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Clippy
+      run: cargo clippy -- -D warnings

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# hjson-lint
+
+![Rust workflow badge](https://github.com/jwnrt/hjson-lint/actions/workflows/rust.yml/badge.svg)
+
+This is a WIP linter for [Hjson] files.
+
+Hjson has some useful features, but can be overly permissive. This tool will
+allowing linting Hjson files to ensure they're easy to read and parse.
+
+[Hjson]: https://hjson.github.io/


### PR DESCRIPTION
This PR adds a README and a GitHub Actions workflow to run the Cargo tests, check the formatting, and run `clippy`.