### PR TITLE
Add basic top-down parser for Hjson structure

### DIFF
--- a/src/lexer/iter.rs
+++ b/src/lexer/iter.rs
@@ -111,9 +111,9 @@ fn next_token(input: &str, text_mode: TextMode) -> Option<Token> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Cursor {
-    line: usize,
-    column: usize,
-    byte_offset: usize,
+    pub line: usize,
+    pub column: usize,
+    pub byte_offset: usize,
 }
 
 impl Default for Cursor {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -41,6 +41,7 @@ impl Token {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TokenKind {
+    Eof,
     Boolean,
     LineComment,
     BlockComment,
@@ -65,6 +66,7 @@ pub enum TokenKind {
 impl Display for TokenKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
+            Self::Eof => "EOF",
             Self::Boolean => "Boolean",
             Self::LineComment => "line comment",
             Self::BlockComment => "block comment",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod lexer;
+pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+use std::io;
+
+use hjson_lint::parser::Parser;
+
 fn main() {
-    println!("Hello, world!");
+    let input = io::read_to_string(io::stdin()).expect("failed to read stdin");
+
+    Parser::parse(&input).expect("failed to parse");
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,228 @@
+use std::error::Error;
+use std::fmt::{self, Display};
+use std::iter::Peekable;
+
+use crate::lexer::{Cursor, Token, TokenKind, Tokens};
+
+type ParseResult<T> = Result<T, ParseError>;
+
+pub struct Parser<'a> {
+    tokens: Peekable<Tokens<'a>>,
+    stack: Vec<Token>,
+}
+
+impl<'a> Parser<'a> {
+    const HIDDEN: &[TokenKind] = &[
+        TokenKind::Whitespace,
+        TokenKind::NewLine,
+        TokenKind::LineComment,
+        TokenKind::HashComment,
+        TokenKind::BlockComment,
+    ];
+
+    const HIDDEN_LINE: &[TokenKind] = &[
+        TokenKind::Whitespace,
+        TokenKind::LineComment,
+        TokenKind::HashComment,
+        TokenKind::BlockComment,
+    ];
+
+    const KEY: &[TokenKind] = &[
+        TokenKind::TextSingle,
+        TokenKind::TextDouble,
+        TokenKind::TextUnquoted,
+    ];
+
+    const VALUE: &[TokenKind] = &[
+        TokenKind::Boolean,
+        TokenKind::Integer,
+        TokenKind::Float,
+        TokenKind::TextSingle,
+        TokenKind::TextDouble,
+        TokenKind::TextMulti,
+        TokenKind::TextUnquoted,
+        TokenKind::Null,
+    ];
+
+    pub fn parse(input: &'a str) -> ParseResult<()> {
+        let tokens = Tokens::parse(input).peekable();
+        let mut parser = Self {
+            tokens,
+            stack: Vec::new(),
+        };
+        parser.parse_root()
+    }
+
+    fn parse_root(&mut self) -> ParseResult<()> {
+        self.skip(Self::HIDDEN);
+        let opening_brace = self.eat(&[TokenKind::OpenBrace]);
+
+        self.parse_map_members()?;
+
+        if opening_brace {
+            // Explicit close brace.
+            self.expect(TokenKind::CloseBrace)?;
+        } else {
+            // Implicit close brace.
+            self.expect(TokenKind::Eof)?;
+        }
+
+        Ok(())
+    }
+
+    fn parse_member(&mut self) -> ParseResult<bool> {
+        self.skip(Self::HIDDEN);
+        if !self.eat(Self::KEY) {
+            return Ok(false);
+        }
+
+        self.skip(Self::HIDDEN);
+        self.expect(TokenKind::Colon)?;
+
+        self.skip(Self::HIDDEN);
+        self.expect_value()?;
+
+        Ok(true)
+    }
+
+    fn parse_value(&mut self) -> ParseResult<bool> {
+        self.skip(Self::HIDDEN);
+
+        if self.parse_map()? {
+            return Ok(true);
+        }
+
+        if self.parse_array()? {
+            return Ok(true);
+        }
+
+        if self.eat(Self::VALUE) {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn parse_map(&mut self) -> ParseResult<bool> {
+        self.skip(Self::HIDDEN);
+
+        if !self.eat(&[TokenKind::OpenBrace]) {
+            return Ok(false);
+        }
+
+        self.skip(Self::HIDDEN);
+        self.parse_map_members()?;
+
+        self.expect(TokenKind::CloseBrace)?;
+
+        Ok(true)
+    }
+
+    fn parse_map_members(&mut self) -> ParseResult<()> {
+        loop {
+            self.skip(Self::HIDDEN);
+
+            self.parse_member()?;
+
+            self.skip(Self::HIDDEN_LINE);
+            if !self.eat(&[TokenKind::Comma, TokenKind::NewLine]) {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn parse_array(&mut self) -> ParseResult<bool> {
+        self.skip(Self::HIDDEN);
+        if !self.eat(&[TokenKind::OpenBracket]) {
+            return Ok(false);
+        }
+
+        loop {
+            self.skip(Self::HIDDEN);
+            self.parse_value()?;
+
+            self.skip(Self::HIDDEN_LINE);
+
+            if !self.eat(&[TokenKind::Comma, TokenKind::NewLine]) {
+                break;
+            }
+        }
+
+        self.skip(Self::HIDDEN);
+        self.expect(TokenKind::CloseBracket)?;
+
+        Ok(true)
+    }
+
+    fn expect_value(&mut self) -> ParseResult<bool> {
+        self.skip(Self::HIDDEN);
+        if self.parse_value()? {
+            return Ok(true);
+        }
+
+        // This iterator returns an EOF token at the end (not `None`), so we can expect it.
+        let (cursor, token) = self.tokens.next().expect("expected token");
+
+        Err(ParseError {
+            cursor,
+            expected: String::from("value"),
+            got: token.kind,
+        })
+    }
+
+    fn eat(&mut self, kinds: &[TokenKind]) -> bool {
+        let Some((_, next)) = self.tokens.peek() else {
+            return false;
+        };
+
+        if kinds.contains(&next.kind) {
+            let (_, token) = self.tokens.next().expect("expected token");
+            self.stack.push(token);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn skip(&mut self, kinds: &[TokenKind]) {
+        while self.eat(kinds) {}
+    }
+
+    fn expect(&mut self, kind: TokenKind) -> ParseResult<()> {
+        // This iterator returns an EOF token at the end (not `None`), so we can expect it.
+        let (cursor, token) = self.tokens.next().expect("expected token");
+
+        if token.kind == kind {
+            self.stack.push(token);
+            Ok(())
+        } else {
+            Err(ParseError {
+                cursor,
+                expected: kind.to_string(),
+                got: token.kind,
+            })
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ParseError {
+    cursor: Cursor,
+    expected: String,
+    got: TokenKind,
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            expected,
+            got,
+            cursor: Cursor { line, column, .. },
+        } = self;
+        write!(f, "{line}:{column}: expected {expected}, got {got}",)
+    }
+}
+
+impl Error for ParseError {}


### PR DESCRIPTION
This PR adds a simple top-down parser for Hjson file structure, throwing errors when something's wrong.

I haven't thoroughly tested this, and there will no doubt be fixes in the future, but it's helpful in its current state.

It's also mostly undocumented again. I really will go and add rustdoc in the future, promise.