### PR TITLE
Produce a format-preserving AST from parsing

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -12,7 +12,7 @@ use std::fmt::{self, Display};
 
 pub use boolean::Boolean;
 pub use comment::Comment;
-pub use iter::{Cursor, Tokens};
+pub use iter::{Cursor, Span, Tokens};
 pub use key::Key;
 pub use null::Null;
 pub use number::Number;
@@ -25,7 +25,7 @@ trait Parse: Sized {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Token {
+struct Token {
     pub kind: TokenKind,
     pub len: usize,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,5 +5,7 @@ use hjson_lint::parser::Parser;
 fn main() {
     let input = io::read_to_string(io::stdin()).expect("failed to read stdin");
 
-    Parser::parse(&input).expect("failed to parse");
+    let root = Parser::parse(&input).expect("failed to parse");
+
+    println!("{root:#?}");
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,0 +1,53 @@
+use crate::lexer::Token;
+
+#[derive(Clone, Debug)]
+pub struct Node<T> {
+    _before: Vec<Token>,
+    _inner: T,
+    _after: Vec<Token>,
+}
+
+impl<T> Node<T> {
+    pub fn new(before: Vec<Token>, inner: T, after: Vec<Token>) -> Self {
+        Self {
+            _before: before,
+            _inner: inner,
+            _after: after,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Map {
+    pub open_brace: Option<Node<Token>>,
+    pub members: Vec<Node<MapMember>>,
+    pub close_brace: Option<Node<Token>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MapMember {
+    pub key: Token,
+    pub colon: Node<Token>,
+    pub value: Value,
+    pub comma: Option<Node<Token>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Array {
+    pub open_bracket: Node<Token>,
+    pub members: Vec<Node<ArrayMember>>,
+    pub close_bracket: Node<Token>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ArrayMember {
+    pub value: Value,
+    pub comma: Option<Node<Token>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Value {
+    Map(Map),
+    Array(Array),
+    Value(Token),
+}

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -1,14 +1,14 @@
-use crate::lexer::Token;
+use crate::lexer::Span;
 
 #[derive(Clone, Debug)]
 pub struct Node<T> {
-    _before: Vec<Token>,
+    _before: Vec<Span>,
     _inner: T,
-    _after: Vec<Token>,
+    _after: Vec<Span>,
 }
 
 impl<T> Node<T> {
-    pub fn new(before: Vec<Token>, inner: T, after: Vec<Token>) -> Self {
+    pub fn new(before: Vec<Span>, inner: T, after: Vec<Span>) -> Self {
         Self {
             _before: before,
             _inner: inner,
@@ -19,35 +19,35 @@ impl<T> Node<T> {
 
 #[derive(Clone, Debug)]
 pub struct Map {
-    pub open_brace: Option<Node<Token>>,
+    pub open_brace: Option<Node<Span>>,
     pub members: Vec<Node<MapMember>>,
-    pub close_brace: Option<Node<Token>>,
+    pub close_brace: Option<Node<Span>>,
 }
 
 #[derive(Clone, Debug)]
 pub struct MapMember {
-    pub key: Token,
-    pub colon: Node<Token>,
+    pub key: Span,
+    pub colon: Node<Span>,
     pub value: Value,
-    pub comma: Option<Node<Token>>,
+    pub comma: Option<Node<Span>>,
 }
 
 #[derive(Clone, Debug)]
 pub struct Array {
-    pub open_bracket: Node<Token>,
+    pub open_bracket: Node<Span>,
     pub members: Vec<Node<ArrayMember>>,
-    pub close_bracket: Node<Token>,
+    pub close_bracket: Node<Span>,
 }
 
 #[derive(Clone, Debug)]
 pub struct ArrayMember {
     pub value: Value,
-    pub comma: Option<Node<Token>>,
+    pub comma: Option<Node<Span>>,
 }
 
 #[derive(Clone, Debug)]
 pub enum Value {
     Map(Map),
     Array(Array),
-    Value(Token),
+    Value(Span),
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,10 +1,16 @@
 use std::error::Error;
 use std::fmt::{self, Display};
+use std::iter;
 use std::iter::Peekable;
+use std::mem;
 
 use crate::lexer::{Cursor, Token, TokenKind, Tokens};
 
 type ParseResult<T> = Result<T, ParseError>;
+
+mod ast;
+
+use ast::Node;
 
 pub struct Parser<'a> {
     tokens: Peekable<Tokens<'a>>,
@@ -43,112 +49,207 @@ impl<'a> Parser<'a> {
         TokenKind::Null,
     ];
 
-    pub fn parse(input: &'a str) -> ParseResult<()> {
+    pub fn parse(input: &'a str) -> ParseResult<Node<ast::Map>> {
         let tokens = Tokens::parse(input).peekable();
         let mut parser = Self { tokens };
 
         parser.parse_root()
     }
 
-    fn parse_root(&mut self) -> ParseResult<()> {
-        self.skip(Self::HIDDEN);
-        let opening_brace = self.eat(&[TokenKind::OpenBrace]);
+    fn parse_root(&mut self) -> ParseResult<Node<ast::Map>> {
+        let before = self.skip(Self::HIDDEN);
 
-        self.parse_map_members()?;
+        let open_brace = self
+            .eat(&[TokenKind::OpenBrace])
+            .map(|token| Node::new(Vec::new(), token, self.skip(Self::HIDDEN_LINE)));
 
-        if opening_brace {
+        let members = self.parse_map_members()?;
+
+        let (close_brace, after) = if open_brace.is_some() {
             // Explicit close brace.
-            self.expect(TokenKind::CloseBrace)?;
+            let close_brace = Some(Node::new(
+                self.skip(Self::HIDDEN),
+                self.expect(TokenKind::CloseBrace)?,
+                Vec::new(),
+            ));
+
+            (close_brace, self.skip(Self::HIDDEN))
         } else {
             // Implicit close brace.
+            let after = self.skip(Self::HIDDEN);
             self.expect(TokenKind::Eof)?;
-        }
 
-        Ok(())
+            (None, after)
+        };
+
+        let node = Node::new(
+            before,
+            ast::Map {
+                open_brace,
+                members,
+                close_brace,
+            },
+            after,
+        );
+
+        Ok(node)
     }
 
-    fn parse_map_members(&mut self) -> ParseResult<()> {
-        loop {
-            self.skip(Self::HIDDEN);
-            if !self.eat(Self::KEY) {
-                break;
-            }
-
-            self.skip(Self::HIDDEN);
-            self.expect(TokenKind::Colon)?;
-
-            self.skip(Self::HIDDEN);
-            self.expect_value()?;
-
-            self.skip(Self::HIDDEN_LINE);
-            if !self.eat(&[TokenKind::Comma, TokenKind::NewLine]) {
-                break;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn parse_value(&mut self) -> ParseResult<bool> {
-        self.skip(Self::HIDDEN);
-
-        if self.parse_map()? {
-            return Ok(true);
-        }
-
-        if self.parse_array()? {
-            return Ok(true);
-        }
-
-        if self.eat(Self::VALUE) {
-            return Ok(true);
-        }
-
-        Ok(false)
-    }
-
-    fn parse_map(&mut self) -> ParseResult<bool> {
-        self.skip(Self::HIDDEN);
-
-        if !self.eat(&[TokenKind::OpenBrace]) {
-            return Ok(false);
-        }
-
-        self.skip(Self::HIDDEN);
-        self.parse_map_members()?;
-
-        self.expect(TokenKind::CloseBrace)?;
-
-        Ok(true)
-    }
-
-    fn parse_array(&mut self) -> ParseResult<bool> {
-        self.skip(Self::HIDDEN);
-        if !self.eat(&[TokenKind::OpenBracket]) {
-            return Ok(false);
-        }
+    fn parse_map_members(&mut self) -> ParseResult<Vec<Node<ast::MapMember>>> {
+        let mut members = Vec::new();
 
         loop {
-            self.skip(Self::HIDDEN);
-            self.parse_value()?;
+            let before = self.skip(Self::HIDDEN);
 
-            self.skip(Self::HIDDEN_LINE);
-
-            if !self.eat(&[TokenKind::Comma, TokenKind::NewLine]) {
+            let Some(key) = self.eat(Self::KEY) else {
                 break;
-            }
+            };
+
+            let colon = Node::new(
+                self.skip(Self::HIDDEN),
+                self.expect(TokenKind::Colon)?,
+                self.skip(Self::HIDDEN),
+            );
+
+            let value = self.expect_value()?;
+
+            let mut after = self.skip(Self::HIDDEN_LINE);
+
+            let comma = if let Some(comma) = self.eat(&[TokenKind::Comma]) {
+                // Explicit comma.
+                let before = mem::take(&mut after);
+                let node = Node::new(before, comma, self.skip(Self::HIDDEN));
+                Some(node)
+            } else if let Some(newline) = self.eat(&[TokenKind::NewLine]) {
+                // Implicit comma.
+                after.push(newline);
+                None
+            } else {
+                // End of members.
+                break;
+            };
+
+            after.extend(self.skip(Self::HIDDEN));
+
+            let node = Node::new(
+                before,
+                ast::MapMember {
+                    key,
+                    colon,
+                    value,
+                    comma,
+                },
+                after,
+            );
+            members.push(node);
         }
 
-        self.skip(Self::HIDDEN);
-        self.expect(TokenKind::CloseBracket)?;
-
-        Ok(true)
+        Ok(members)
     }
 
-    fn expect_value(&mut self) -> ParseResult<bool> {
-        self.skip(Self::HIDDEN);
-        if self.parse_value()? {
-            return Ok(true);
+    fn parse_value(&mut self) -> ParseResult<Option<ast::Value>> {
+        let map = self.parse_map()?.map(ast::Value::Map);
+        if map.is_some() {
+            return Ok(map);
+        }
+
+        let array = self.parse_array()?.map(ast::Value::Array);
+        if array.is_some() {
+            return Ok(array);
+        }
+
+        let value = self.eat(Self::VALUE).map(ast::Value::Value);
+        if value.is_some() {
+            return Ok(value);
+        }
+
+        Ok(None)
+    }
+
+    fn parse_map(&mut self) -> ParseResult<Option<ast::Map>> {
+        let Some(open_brace) = self.eat(&[TokenKind::OpenBrace]) else {
+            return Ok(None)
+        };
+
+        let open_brace = Some(Node::new(
+            Vec::new(),
+            open_brace,
+            self.skip(Self::HIDDEN_LINE),
+        ));
+
+        let members = self.parse_map_members()?;
+
+        let close_brace = Some(Node::new(
+            self.skip(Self::HIDDEN),
+            self.expect(TokenKind::CloseBrace)?,
+            Vec::new(),
+        ));
+
+        let map = ast::Map {
+            open_brace,
+            members,
+            close_brace,
+        };
+
+        Ok(Some(map))
+    }
+
+    fn parse_array(&mut self) -> ParseResult<Option<ast::Array>> {
+        let open_bracket = self.eat(&[TokenKind::OpenBracket]);
+
+        let Some(open_bracket) = open_bracket else {
+            return Ok(None);
+        };
+
+        let open_bracket = Node::new(Vec::new(), open_bracket, self.skip(Self::HIDDEN_LINE));
+
+        let mut members = Vec::new();
+
+        let mut before;
+        loop {
+            // if there's no value, this should become part of the close bracket's `before`.
+            before = self.skip(Self::HIDDEN);
+
+            let Some(value) = self.parse_value()? else {
+                break;
+            };
+
+            let mut after = self.skip(Self::HIDDEN_LINE);
+
+            let comma = if let Some(comma) = self.eat(&[TokenKind::Comma]) {
+                // Explicit comma.
+                let before = mem::take(&mut after);
+                let node = Node::new(before, comma, self.skip(Self::HIDDEN));
+                Some(node)
+            } else if let Some(newline) = self.eat(&[TokenKind::NewLine]) {
+                // Implicit comma.
+                after.push(newline);
+                None
+            } else {
+                // End of members.
+                break;
+            };
+
+            let node = Node::new(before, ast::ArrayMember { value, comma }, after);
+            members.push(node);
+        }
+
+        before.append(&mut self.skip(Self::HIDDEN));
+
+        let close_bracket = Node::new(before, self.expect(TokenKind::CloseBracket)?, Vec::new());
+
+        let array = ast::Array {
+            open_bracket,
+            members,
+            close_bracket,
+        };
+
+        Ok(Some(array))
+    }
+
+    fn expect_value(&mut self) -> ParseResult<ast::Value> {
+        if let Some(value) = self.parse_value()? {
+            return Ok(value);
         }
 
         // This iterator returns an EOF token at the end (not `None`), so we can expect it.
@@ -161,29 +262,31 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn eat(&mut self, kinds: &[TokenKind]) -> bool {
+    #[must_use]
+    fn eat(&mut self, kinds: &[TokenKind]) -> Option<Token> {
         let Some((_, next)) = self.tokens.peek() else {
-            return false;
+            return None;
         };
 
         if kinds.contains(&next.kind) {
             let (_, token) = self.tokens.next().expect("expected token");
-            true
+            Some(token)
         } else {
-            false
+            None
         }
     }
 
-    fn skip(&mut self, kinds: &[TokenKind]) {
-        while self.eat(kinds) {}
+    #[must_use]
+    fn skip(&mut self, kinds: &[TokenKind]) -> Vec<Token> {
+        iter::from_fn(|| self.eat(kinds)).collect()
     }
 
-    fn expect(&mut self, kind: TokenKind) -> ParseResult<()> {
+    fn expect(&mut self, kind: TokenKind) -> ParseResult<Token> {
         // This iterator returns an EOF token at the end (not `None`), so we can expect it.
         let (cursor, token) = self.tokens.next().expect("expected token");
 
         if token.kind == kind {
-            Ok(())
+            Ok(token)
         } else {
             Err(ParseError {
                 cursor,


### PR DESCRIPTION
This PR modifies the parser to produce a format-preserving AST.

The AST mostly just reflects the structure of Hjson, but there's this `Node<T>` type which has `before` and `after` fields for storing decorations (whitespace, comments).

This will be used by the linter to check correct indentation and spacing etc.