### PR TITLE
Parser and linter fixes

### DIFF
--- a/src/lexer/number.rs
+++ b/src/lexer/number.rs
@@ -64,9 +64,7 @@ impl Parse for Number {
         // an unquoted string that started with a digit.
         // We strip whitespace first (except for newlines).
         let term_symbols = [',', ':', '[', ']', '{', '}', '\n'];
-        let input = input
-            .strip_prefix(|c: char| c.is_whitespace() && c != '\n')
-            .unwrap_or(input);
+        let input = input.trim_start_matches(|c: char| c.is_whitespace() && c != '\n');
         match input.is_empty() || input.starts_with(|c: char| term_symbols.contains(&c)) {
             true => Some(Token::new(kind, len)),
             false => None,
@@ -147,5 +145,13 @@ mod test {
         for case in bad_cases {
             assert_eq!(Number::parse(case), None);
         }
+    }
+
+    #[test]
+    fn terminate() {
+        assert!(Number::parse("5 ").is_some());
+        assert!(Number::parse("5}").is_some());
+        assert!(Number::parse("5 }").is_some());
+        assert!(Number::parse("5  \t}").is_some());
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -3,7 +3,7 @@ use crate::lexer::Span;
 #[derive(Clone, Debug)]
 pub struct Node<T> {
     _before: Vec<Span>,
-    _inner: T,
+    pub inner: T,
     _after: Vec<Span>,
 }
 
@@ -11,7 +11,7 @@ impl<T> Node<T> {
     pub fn new(before: Vec<Span>, inner: T, after: Vec<Span>) -> Self {
         Self {
             _before: before,
-            _inner: inner,
+            inner,
             _after: after,
         }
     }
@@ -19,9 +19,9 @@ impl<T> Node<T> {
 
 #[derive(Clone, Debug)]
 pub struct Map {
-    pub open_brace: Option<Node<Span>>,
+    pub open_brace: Node<Option<Span>>,
     pub members: Vec<Node<MapMember>>,
-    pub close_brace: Option<Node<Span>>,
+    pub close_brace: Node<Option<Span>>,
 }
 
 #[derive(Clone, Debug)]
@@ -29,7 +29,7 @@ pub struct MapMember {
     pub key: Span,
     pub colon: Node<Span>,
     pub value: Value,
-    pub comma: Option<Node<Span>>,
+    pub comma: Node<Option<Span>>,
 }
 
 #[derive(Clone, Debug)]
@@ -42,7 +42,7 @@ pub struct Array {
 #[derive(Clone, Debug)]
 pub struct ArrayMember {
     pub value: Value,
-    pub comma: Option<Node<Span>>,
+    pub comma: Node<Option<Span>>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This PR includes:

1. A fix for numbers not being lexed properly when followed by multiple kinds of whitespace (e.g. a space _and_ a tab).
2. A fix to the parser's handling of implicit braces and commas.
   * The changes there make implicit commas behave correctly in the face of EOF.
   * This does introduce weird behaviour where EOF is now not taken off the stack by `eat`, but is by `expect`.
   * Refactoring that would be good.
3. An improvement to how implicit braces and commas are stored in the AST.
   * `Option<Node<...>>` was changed to `Node<Option<...>>` so we have information on where an implicit comma/brace would have been even if it's not there.
   * This makes messages better when linting as we can tell the user where the comma _should_ go.