### PR TITLE
Add first pass on a linter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod lexer;
+pub mod linter;
 pub mod parser;

--- a/src/linter/config.rs
+++ b/src/linter/config.rs
@@ -25,11 +25,10 @@ pub struct Config {
 }
 
 impl Default for Config {
-    /// By default, we `Allow` all Hjson features and only deny obvious
-    /// style issues (e.g. trailing whitespace).
+    /// Allow everything by default so lints can be opted into.
     fn default() -> Self {
         Self {
-            trailing_whitespace: AllowDeny::Deny,
+            trailing_whitespace: AllowDeny::Allow,
             root_braces: AllowDenyRequire::Allow,
             missing_commas: AllowDeny::Allow,
             trailing_commas: AllowDenyRequire::Allow,

--- a/src/linter/config.rs
+++ b/src/linter/config.rs
@@ -1,0 +1,69 @@
+/// Configuration for which linting rules to apply.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Config {
+    /// Whether to allow or deny trailing whitespace at the ends of lines.
+    pub trailing_whitespace: AllowDeny,
+
+    /// Whether to allow, deny, or require that braces `{ ... }` surround
+    /// the whole document.
+    pub root_braces: AllowDenyRequire,
+
+    /// Whether to allow or deny omitting commas at the ends of lines.
+    pub missing_commas: AllowDeny,
+
+    /// Whether to allow, deny, or require adding trailing commas to the
+    /// final member of a map or array.
+    pub trailing_commas: AllowDenyRequire,
+
+    /// Whether to allow, deny, or require (where permitted) that string
+    /// values are unquoted.
+    pub unquoted_values: AllowDenyRequire,
+
+    /// Whether to allow, deny, or require (where permitted) that map keys
+    /// are unquoted.
+    pub unquoted_keys: AllowDenyRequire,
+}
+
+impl Default for Config {
+    /// By default, we `Allow` all Hjson features and only deny obvious
+    /// style issues (e.g. trailing whitespace).
+    fn default() -> Self {
+        Self {
+            trailing_whitespace: AllowDeny::Deny,
+            root_braces: AllowDenyRequire::Allow,
+            missing_commas: AllowDeny::Allow,
+            trailing_commas: AllowDenyRequire::Allow,
+            unquoted_values: AllowDenyRequire::Allow,
+            unquoted_keys: AllowDenyRequire::Allow,
+        }
+    }
+}
+
+impl Config {
+    /// Strict configuration which reflects vanilla JSON syntax.
+    pub fn strict() -> Self {
+        Self {
+            trailing_whitespace: AllowDeny::Deny,
+            root_braces: AllowDenyRequire::Require,
+            missing_commas: AllowDeny::Deny,
+            trailing_commas: AllowDenyRequire::Deny,
+            unquoted_values: AllowDenyRequire::Deny,
+            unquoted_keys: AllowDenyRequire::Deny,
+        }
+    }
+}
+
+/// States for allowing or denying some rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AllowDeny {
+    Allow,
+    Deny,
+}
+
+/// States for allowing, denying, or requiring some rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AllowDenyRequire {
+    Require,
+    Allow,
+    Deny,
+}

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -1,17 +1,51 @@
+mod config;
+
+use std::fmt::{self, Display};
+
+use crate::lexer::Cursor;
 use crate::parser::ast::{Array, ArrayMember, Map, MapMember, Node, Value};
 use crate::parser::{ParseError, Parser};
 
+pub use self::config::Config;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Lint {
+    kind: LintKind,
+    span: LintSpan,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LintSpan {
+    start: Cursor,
+    len: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LintKind {}
+
+impl Display for LintKind {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Default)]
-pub struct Linter;
+pub struct Linter {
+    config: Config,
+    lints: Vec<Lint>,
+}
 
 impl Linter {
-    pub fn lint(input: &str) -> Result<(), ParseError> {
-        let mut linter = Linter::default();
+    pub fn lint(config: Config, input: &str) -> Result<Vec<Lint>, ParseError> {
+        let mut linter = Linter {
+            config,
+            lints: Vec::new(),
+        };
 
         let ast = Parser::parse(input)?;
         linter.lint_root(&ast);
 
-        Ok(())
+        Ok(linter.lints)
     }
 
     fn lint_root(&mut self, map: &Map) {
@@ -19,7 +53,7 @@ impl Linter {
     }
 
     fn lint_map(&mut self, map: &Map) {
-        for map_member in &map.members {
+        for map_member in map.members.iter() {
             self.lint_map_member(map_member);
         }
     }
@@ -29,7 +63,7 @@ impl Linter {
     }
 
     fn lint_array(&mut self, array: &Array) {
-        for array_member in &array.members {
+        for array_member in array.members.iter() {
             self.lint_array_member(array_member);
         }
     }

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -1,0 +1,48 @@
+use crate::parser::ast::{Array, ArrayMember, Map, MapMember, Node, Value};
+use crate::parser::{ParseError, Parser};
+
+#[derive(Clone, Debug, Default)]
+pub struct Linter;
+
+impl Linter {
+    pub fn lint(input: &str) -> Result<(), ParseError> {
+        let mut linter = Linter::default();
+
+        let ast = Parser::parse(input)?;
+        linter.lint_root(&ast);
+
+        Ok(())
+    }
+
+    fn lint_root(&mut self, map: &Map) {
+        self.lint_map(map);
+    }
+
+    fn lint_map(&mut self, map: &Map) {
+        for map_member in &map.members {
+            self.lint_map_member(map_member);
+        }
+    }
+
+    fn lint_map_member(&mut self, map_member: &Node<MapMember>) {
+        self.lint_value(&map_member.inner.value);
+    }
+
+    fn lint_array(&mut self, array: &Array) {
+        for array_member in &array.members {
+            self.lint_array_member(array_member);
+        }
+    }
+
+    fn lint_array_member(&mut self, array_member: &Node<ArrayMember>) {
+        self.lint_value(&array_member.inner.value);
+    }
+
+    fn lint_value(&mut self, value: &Value) {
+        let _value = match value {
+            Value::Map(map) => return self.lint_map(map),
+            Value::Array(array) => return self.lint_array(array),
+            Value::Value(value) => value,
+        };
+    }
+}

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -24,6 +24,8 @@ pub struct LintSpan {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LintKind {
     ImplicitBraces,
+    MissingComma,
+    TrailingComma,
     TrailingWhitespace,
 }
 
@@ -31,6 +33,8 @@ impl Display for LintKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LintKind::ImplicitBraces => f.write_str("implicit braces"),
+            LintKind::MissingComma => f.write_str("missing comma"),
+            LintKind::TrailingComma => f.write_str("trailing comma"),
             LintKind::TrailingWhitespace => f.write_str("trailing whitespace"),
         }
     }
@@ -64,27 +68,39 @@ impl Linter {
         self.lint_trailing_whitespace(&map.open_brace);
         self.lint_trailing_whitespace(&map.close_brace);
 
-        for map_member in map.members.iter() {
-            self.lint_map_member(map_member);
+        for (i, map_member) in map.members.iter().enumerate() {
+            self.lint_map_member(map_member, i == map.members.len() - 1);
         }
     }
 
-    fn lint_map_member(&mut self, map_member: &Node<MapMember>) {
+    fn lint_map_member(&mut self, map_member: &Node<MapMember>, last: bool) {
         self.lint_trailing_whitespace(map_member);
         self.lint_trailing_whitespace(&map_member.inner.comma);
         self.lint_value(&map_member.inner.value);
-    }
 
-    fn lint_array(&mut self, array: &Array) {
-        for array_member in array.members.iter() {
-            self.lint_array_member(array_member);
+        if last {
+            self.lint_trailing_comma(&map_member.inner.comma);
+        } else {
+            self.lint_missing_comma(&map_member.inner.comma);
         }
     }
 
-    fn lint_array_member(&mut self, array_member: &Node<ArrayMember>) {
+    fn lint_array(&mut self, array: &Array) {
+        for (i, array_member) in array.members.iter().enumerate() {
+            self.lint_array_member(array_member, i == array.members.len() - 1);
+        }
+    }
+
+    fn lint_array_member(&mut self, array_member: &Node<ArrayMember>, last: bool) {
         self.lint_trailing_whitespace(array_member);
         self.lint_trailing_whitespace(&array_member.inner.comma);
         self.lint_value(&array_member.inner.value);
+
+        if last {
+            self.lint_trailing_comma(&array_member.inner.comma);
+        } else {
+            self.lint_missing_comma(&array_member.inner.comma);
+        }
     }
 
     fn lint_value(&mut self, value: &Value) {
@@ -176,6 +192,74 @@ impl Linter {
                 });
             }
             _ => (),
+        }
+    }
+
+    fn lint_trailing_comma(&mut self, comma: &Node<Option<Span>>) {
+        if self.config.trailing_commas == AllowDenyRequire::Allow {
+            return;
+        }
+
+        // If this comma site isn't followed by a new line, we don't treat it as trailing.
+        if !comma
+            .after
+            .iter()
+            .any(|span| span.kind == TokenKind::NewLine || span.kind == TokenKind::Eof)
+        {
+            return;
+        };
+
+        let first = comma
+            .before
+            .iter()
+            .chain(comma.after.iter())
+            .next()
+            .expect("expected some space where comma is");
+
+        // Check for trailing commas.
+        match self.config.trailing_commas {
+            AllowDenyRequire::Deny => {
+                if let Some(ref node) = comma.inner {
+                    self.lints.push(Lint {
+                        kind: LintKind::TrailingComma,
+                        span: LintSpan {
+                            start: node.start,
+                            len: node.len,
+                        },
+                    })
+                }
+            }
+            AllowDenyRequire::Require if comma.inner.is_none() => self.lints.push(Lint {
+                kind: LintKind::TrailingComma,
+                span: LintSpan {
+                    start: comma.before.first().map_or(first.start, |span| span.start),
+                    len: 0,
+                },
+            }),
+            _ => (),
+        }
+    }
+
+    fn lint_missing_comma(&mut self, comma: &Node<Option<Span>>) {
+        if self.config.missing_commas == AllowDeny::Allow {
+            return;
+        }
+
+        let first = comma
+            .before
+            .iter()
+            .chain(comma.after.iter())
+            .next()
+            .expect("expected some space where comma is");
+
+        if comma.inner.is_none() {
+            self.lints.push(Lint {
+                kind: LintKind::MissingComma,
+                span: LintSpan {
+                    start: first.start,
+                    len: 0,
+                },
+            })
         }
     }
 }
@@ -300,5 +384,229 @@ mod test {
                 }
             }])
         );
+    }
+
+    #[test]
+    fn allow_trailing_commas() {
+        let conf = Config {
+            trailing_commas: AllowDenyRequire::Allow,
+            ..Default::default()
+        };
+
+        assert!(Linter::lint(conf, "'foo': 3").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'foo': 3,").unwrap().is_empty());
+        assert!(Linter::lint(conf, "{ 'foo': 3 }").unwrap().is_empty());
+        assert!(Linter::lint(conf, "{ 'foo': 3, }").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'foo': 3\n").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'foo': 3 \t\n").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'foo': 3,\n").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'foo': 3, \t\n").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3 ]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3, ]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3\n]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3 \t\n]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3,\n]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3, \t\n]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn deny_trailing_commas() {
+        let conf = Config {
+            trailing_commas: AllowDenyRequire::Deny,
+            ..Default::default()
+        };
+
+        // No trailing commas for maps.
+        assert!(Linter::lint(conf, "'foo': 3").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'foo': 3 \t\n").unwrap().is_empty());
+        assert!(Linter::lint(conf, "{ 'foo': 3 \t}").unwrap().is_empty());
+        assert!(Linter::lint(conf, "{ 'foo': 3,\n'bar': 5\n}")
+            .unwrap()
+            .is_empty());
+
+        // No trailing commas for arrays.
+        assert!(Linter::lint(conf, "'a': [ 3 ]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3\n]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3 \t\n]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3, 5 ]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3,\n5\n]").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'a': [ 3, 5 \t\n]").unwrap().is_empty());
+
+        // Single map member with trailing comma.
+        assert_eq!(
+            Linter::lint(conf, "'foo': 3,").unwrap(),
+            Vec::from([Lint {
+                kind: LintKind::TrailingComma,
+                span: LintSpan {
+                    start: Cursor {
+                        line: 1,
+                        column: 9,
+                        byte_offset: 8,
+                    },
+                    len: 1
+                }
+            }])
+        );
+        // Two map members, only one comma is trailing.
+        assert_eq!(
+            Linter::lint(conf, "'foo': 3,\n'bar': 5,").unwrap(),
+            Vec::from([Lint {
+                kind: LintKind::TrailingComma,
+                span: LintSpan {
+                    start: Cursor {
+                        line: 2,
+                        column: 9,
+                        byte_offset: 18,
+                    },
+                    len: 1
+                }
+            }])
+        );
+
+        // Single array member with a trailing comma.
+        assert_eq!(
+            Linter::lint(conf, "'a': [\n3,\n]").unwrap(),
+            Vec::from([Lint {
+                kind: LintKind::TrailingComma,
+                span: LintSpan {
+                    start: Cursor {
+                        line: 2,
+                        column: 2,
+                        byte_offset: 8,
+                    },
+                    len: 1
+                }
+            }])
+        );
+        // Two array members, only one comma is trailing.
+        assert_eq!(
+            Linter::lint(conf, "'a': [\n3,\n5,\n]").unwrap(),
+            Vec::from([Lint {
+                kind: LintKind::TrailingComma,
+                span: LintSpan {
+                    start: Cursor {
+                        line: 3,
+                        column: 2,
+                        byte_offset: 11,
+                    },
+                    len: 1
+                }
+            }])
+        );
+
+        // Trailing commas closed on the same line are currently ignored,
+        // but we should have a lint for them in the future.
+        assert_eq!(Linter::lint(conf, "{ 'foo': 3, }").unwrap(), Vec::new());
+        assert_eq!(Linter::lint(conf, "{ 'a': [ 3, ] }").unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn require_trailing_commas() {
+        let conf = Config {
+            trailing_commas: AllowDenyRequire::Require,
+            ..Default::default()
+        };
+
+        // Trailing comma provided.
+        assert!(Linter::lint(conf, "{ 'foo': 3,\n}").unwrap().is_empty());
+        assert!(Linter::lint(conf, "{ 'foo': 3, \t\n}").unwrap().is_empty());
+        assert!(Linter::lint(conf, "{ 'a': [ 3,\n] }").unwrap().is_empty());
+        assert!(Linter::lint(conf, "{ 'a': [ 3, \t\n] }")
+            .unwrap()
+            .is_empty());
+
+        let lints = Vec::from([Lint {
+            kind: LintKind::TrailingComma,
+            span: LintSpan {
+                start: Cursor {
+                    line: 1,
+                    column: 9,
+                    byte_offset: 8,
+                },
+                len: 0,
+            },
+        }]);
+        // One map member, trailing comma not provided.
+        assert_eq!(Linter::lint(conf, "'foo': 3").unwrap(), lints);
+        assert_eq!(Linter::lint(conf, "'foo': 3\n").unwrap(), lints);
+        assert_eq!(Linter::lint(conf, "'foo': 3 \t\n").unwrap(), lints);
+        // One array member, trailing comma not provided.
+        assert_eq!(Linter::lint(conf, "'a': [ 3\n],").unwrap(), lints);
+        assert_eq!(Linter::lint(conf, "'a': [ 3 \t\n],").unwrap(), lints);
+
+        let lints = Vec::from([Lint {
+            kind: LintKind::TrailingComma,
+            span: LintSpan {
+                start: Cursor {
+                    line: 2,
+                    column: 7,
+                    byte_offset: 14,
+                },
+                len: 0,
+            },
+        }]);
+        // Two map members, trailing comma not provided.
+        assert_eq!(Linter::lint(conf, "'x': 3,\n'y': 5").unwrap(), lints);
+        assert_eq!(Linter::lint(conf, "'x': 3,\n'y': 5\n").unwrap(), lints);
+        assert_eq!(Linter::lint(conf, "'x': 3,\n'y': 5 \t\n").unwrap(), lints);
+
+        let lints = Vec::from([Lint {
+            kind: LintKind::TrailingComma,
+            span: LintSpan {
+                start: Cursor {
+                    line: 2,
+                    column: 2,
+                    byte_offset: 14,
+                },
+                len: 0,
+            },
+        }]);
+        // Two map members, trailing comma not provided.
+        assert_eq!(Linter::lint(conf, "'a': [ 1234,\n5\n],").unwrap(), lints);
+        assert_eq!(Linter::lint(conf, "'a': [ 1234,\n5 \t\n],").unwrap(), lints);
+
+        // Trailing commas closed on the same line are currently ignored,
+        // but we should have a lint for them in the future.
+        assert_eq!(Linter::lint(conf, "{ 'foo': 3 }").unwrap(), Vec::new());
+        assert_eq!(Linter::lint(conf, "{ 'a': [ 3 ] }").unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn allow_missing_commas() {
+        let conf = Config {
+            missing_commas: AllowDeny::Allow,
+            ..Default::default()
+        };
+
+        assert!(Linter::lint(conf, "'x': 3, 'y': 5").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'x': 3,\n'y': 5").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'x': 3\n'y': 5").unwrap().is_empty());
+    }
+
+    #[test]
+    fn deny_missing_commas() {
+        let conf = Config {
+            missing_commas: AllowDeny::Deny,
+            ..Default::default()
+        };
+
+        // No missing commas
+        assert!(Linter::lint(conf, "'x': 3, 'y': 5").unwrap().is_empty());
+        assert!(Linter::lint(conf, "'x': 3,\n'y': 5").unwrap().is_empty());
+
+        let lints = Vec::from([Lint {
+            kind: LintKind::MissingComma,
+            span: LintSpan {
+                start: Cursor {
+                    line: 1,
+                    column: 7,
+                    byte_offset: 6,
+                },
+                len: 0,
+            },
+        }]);
+        // Missing comma (implicit by newline)
+        assert_eq!(Linter::lint(conf, "'x': 3\n'y': 5").unwrap(), lints);
+        assert_eq!(Linter::lint(conf, "'x': 3 \t\n'y': 5").unwrap(), lints);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use std::io;
 
-use hjson_lint::parser::Parser;
+use hjson_lint::linter::Linter;
 
 fn main() {
     let input = io::read_to_string(io::stdin()).expect("failed to read stdin");
 
-    let root = Parser::parse(&input).expect("failed to parse");
+    let lints = Linter::lint(&input).expect("failed to lint");
 
-    println!("{root:#?}");
+    println!("{lints:#?}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use std::io;
 
-use hjson_lint::linter::Linter;
+use hjson_lint::linter::{Config, Linter};
 
 fn main() {
     let input = io::read_to_string(io::stdin()).expect("failed to read stdin");
 
-    let lints = Linter::lint(&input).expect("failed to lint");
+    let lints = Linter::lint(Config::strict(), &input).expect("failed to lint");
 
     println!("{lints:#?}");
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -2,17 +2,17 @@ use crate::lexer::Span;
 
 #[derive(Clone, Debug)]
 pub struct Node<T> {
-    _before: Vec<Span>,
+    pub before: Vec<Span>,
     pub inner: T,
-    _after: Vec<Span>,
+    pub after: Vec<Span>,
 }
 
 impl<T> Node<T> {
     pub fn new(before: Vec<Span>, inner: T, after: Vec<Span>) -> Self {
         Self {
-            _before: before,
+            before,
             inner,
-            _after: after,
+            after,
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,7 +8,7 @@ use crate::lexer::{Cursor, Span, TokenKind, Tokens};
 
 type ParseResult<T> = Result<T, ParseError>;
 
-mod ast;
+pub mod ast;
 
 use ast::Node;
 


### PR DESCRIPTION
This PR adds a basic first pass of a linter which checks a few basic lints:

1. Trailing whitespace
   * I admit that an AST isn't the best place to check for trailing whitespace, as it's likely I might spread whitespace and newlines across distinct types, but oh well.
 2. Implicit root braces.
 3. Missing commas between array/map members.
 4. Trailing commas after the final array/map member.

Most lints can be allow/deny/require, but some only make sense to have allow/deny (why would you require trailing whitespace?).

I'm sure more test cases can and should be added, particularly for trailing whitespace, but I'll do that 20% later.

## Future work

Future lints to be added:

1. Unquoted keys.
2. Unquoted values.
3. Kinds of comments (line, block, hash).

I'm not sure how rigid this architecture is. Yesterday I read a really great article on [error resilient parsing](https://matklad.github.io/2023/05/21/resilient-ll-parsing-tutorial.html) which gives some structure for making a parser that can continue in the face of errors.

The code is very easy to read and gives good results. Maybe something like that would make sense for this linter. We'll see.